### PR TITLE
feat: add status browser info and add back caching to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,5 +26,8 @@ jobs:
         with:
           timezoneLinux: "Europe/Prague"
 
+      - name: Cache
+        run: make cache
+
       - name: Test
         run: make test

--- a/src/projects/status-web3-browser/index.yaml
+++ b/src/projects/status-web3-browser/index.yaml
@@ -4,3 +4,7 @@ categories:
 description: 'Access the latest defi dapps, exchanges, marketplaces, games and more with the Web3 Browser'
 links:
   web: https://status.im/web-three-browser/
+  github: https://github.com/status-im
+  blog: https://status.app/blog
+  twitter: https://twitter.com/ethstatus
+  facebook: https://www.facebook.com/ethstatus/about


### PR DESCRIPTION
As mentioned this PR is to add status browser info to act as trial for deployment, and add back caching for gh test action