### PR TITLE
Fix alliances spell in use case dropdown

### DIFF
--- a/src/usecases.yaml
+++ b/src/usecases.yaml
@@ -37,7 +37,7 @@
 - id: nft-community
   name: NFT community
 - id: alliances
-  name: Allicanes
+  name: Alliances
 - id: mixing-management
   name: Mixing management
 - id: data-management


### PR DESCRIPTION
Changed the spell from Allicanes to Alliances inside projects/usecases.yaml