### PR TITLE
hisoka: update project status to mainnet, add Raven demo, fix links, add team member

### DIFF
--- a/src/projects/hisoka/index.yaml
+++ b/src/projects/hisoka/index.yaml
@@ -33,25 +33,25 @@ assets_used:
 have_token: false
 tokens: []
 links:
-  web: Hisoka.io
-  blog: Hisoka.io/writing
+  web: https://hisoka.io
+  blog: https://hisoka.io/writing
   github: https://github.com/hisoka-io
-  forum: https://x.com/hisoka_io
+  forum: ""
   docs: https://docs.hisoka.io/
   whitepaper: ""
-  block_explorer: https://demo.nox.hisoka.io/
+  block_explorer: https://demo.railgun.hisoka.io
   governance: ""
   twitter: https://x.com/hisoka_io
   discord: ""
   telegram: ""
   lens: ""
   farcaster: ""
-project_phase: testnet
+project_phase: mainnet
 project_status:
   live_status: true
-  mainnet: false
+  mainnet: true
   testnet: true
-  version: testnet
+  version: mainnet
 blockchain_features:
   opensource: true
   upgradability:
@@ -73,8 +73,9 @@ default_privacy: true
 audits: []
 third_party_dependency: Built from fully open-source technologies
 social_trust: There is no centralized custody or DAO for NOX mixnet
-technical_spof: "Hisoka is fully open source with no token or single of failure.
-  NOX, our mixnet is globally distributed. View here: https://map.hisoka.io/"
+technical_spof: "Raven uses single-server PIR -- server learns query timing but
+  not query content. Nox requires at least one honest node per hop (3-hop path).
+  Network map at map.hisoka.io."
 team:
   anonymous: false
   teammembers:
@@ -84,6 +85,8 @@ team:
       link: https://github.com/0xReze
     - name: Jayendra
       link: https://x.com/0xkingpanther
+    - name: Ravi
+      link: https://x.com/0xBejini
 funding: []
 history: []
 id: hisoka

--- a/src/projects/hisoka/index.yaml
+++ b/src/projects/hisoka/index.yaml
@@ -36,7 +36,7 @@ links:
   web: https://hisoka.io
   blog: https://hisoka.io/writing
   github: https://github.com/hisoka-io
-  forum: https://x.com/hisoka_io
+  forum: ""
   docs: https://docs.hisoka.io/
   whitepaper: ""
   block_explorer: https://demo.railgun.hisoka.io

--- a/src/projects/hisoka/index.yaml
+++ b/src/projects/hisoka/index.yaml
@@ -36,7 +36,7 @@ links:
   web: https://hisoka.io
   blog: https://hisoka.io/writing
   github: https://github.com/hisoka-io
-  forum: ""
+  forum: https://x.com/hisoka_io
   docs: https://docs.hisoka.io/
   whitepaper: ""
   block_explorer: https://demo.railgun.hisoka.io


### PR DESCRIPTION
Updating the Hisoka entry with the following changes:

- project_phase + project_status: testnet → mainnet (Raven is live on Ethereum mainnet serving Railgun)
- block_explorer: replaced Nox demo with live Raven PIR demo (demo.railgun.hisoka.io)
- technical_spof: updated to accurately reflect Raven + Nox architecture
- team: added Ravi (@0xBejini)

Submitted by Ravi — https://x.com/0xBejini (Hisoka team)