### PR TITLE
Update test.js - Fix CI failure caused by js-yaml import

### DIFF
--- a/utils/test.js
+++ b/utils/test.js
@@ -1,7 +1,7 @@
 import Ajv from "https://esm.sh/ajv@8.17.1?pin=v58";
 import addFormats from "https://esm.sh/ajv-formats@2.1.1";
 import { betterAjvErrors } from 'https://esm.sh/@apideck/better-ajv-errors@0.3.6?pin=v58';
-import yaml from "npm:js-yaml";
+import * as yaml from "npm:js-yaml";
 
 import { W3PData } from "./w3pdata.js";
 


### PR DESCRIPTION
This change fixes a CI build failure caused by how the js-yaml package was being imported.